### PR TITLE
US-85 add search for combination of terms functionality

### DIFF
--- a/src/tools/DataManager.jsx
+++ b/src/tools/DataManager.jsx
@@ -69,16 +69,20 @@ export default function DataManager({ name, labels = [], entries = [], setEntrie
     }, []);
 
     const filteredEntries = useCallback((entries, search) => {
-
+        
         if (search === '') {
             return entries;
         }
-
+    
+        const searchTerms = search.split('+').map(term => term.trim().toLowerCase());
+    
         return entries.filter((entry) => {
-            return labels.some((label) => {
-                const entryValue = getValue(entry, label);
-                return entryValue?.toString().toLowerCase().includes(search.toLowerCase());
-            });
+            return searchTerms.every((term) => 
+                labels.some((label) => {
+                    const entryValue = getValue(entry, label)?.toString().toLowerCase();
+                    return entryValue?.includes(term);
+                })
+            );
         });
     }, [labels]);
 


### PR DESCRIPTION
Introduced a new constant searchTerms, which is created by splitting the search string using a + delimiter.

Updated the filtering logic to ensure that an entry is included only if every term in searchTerms is found within the values corresponding to the entry’s labels.