### PR TITLE
NoUS - Add adjustable column widths back to main

### DIFF
--- a/src/components/TableEntry.jsx
+++ b/src/components/TableEntry.jsx
@@ -8,6 +8,7 @@ import { getKey, getKeys, getLabel } from '../const/tableLabels';
 import { getSessionEntryCount, startEntryOperation } from '../utils/firestore';
 import { Type, notify } from './Notifier';
 import { FormField } from './FormFields';
+import '../styles/Table.css';
 import React from 'react';
 
 const BINARY_KEYS = ['noCaptures', 'isAlive', 'dead'];
@@ -92,12 +93,12 @@ export const TableEntry = forwardRef((props, ref) => {
                         dbKey={key}
                         entryData={entryData}
                         setEntryData={setEntryData}
-                        className={getLabel(key) === 'Date & Time' ? 'dateTimeColumn' : 
-                            getLabel(key) === 'Site' ? 'siteColumn' : 
-                            getLabel(key) === 'Year' ? 'yearColumn' : 
-                            getLabel(key) === 'Taxa' ? 'taxaColumn' : 
-                            getLabel(key) === 'Genus' ? 'genusColumn' : 
-                            getLabel(key) === 'Species' ? 'speciesColumn' : ''
+                        className={getLabel(key) === 'Date & Time' ? 'dateTimeColumn' :
+                            getLabel(key) === 'Site' ? 'siteColumn' :
+                                getLabel(key) === 'Year' ? 'yearColumn' :
+                                    getLabel(key) === 'Taxa' ? 'taxaColumn' :
+                                        getLabel(key) === 'Genus' ? 'genusColumn' :
+                                            getLabel(key) === 'Species' ? 'speciesColumn' : ''
                         }
                     />
                 )
@@ -132,11 +133,12 @@ const EntryItem = ({ entrySnapshot, dbKey, entryUIState, setEntryData, entryData
     const size = entryData[dbKey] ? String(entryData[dbKey]).length : 1;
 
     return (
+
         //<td className="text-center border-b border-neutral-400 dark:border-neutral-600 p-1">
         <td className={`text-left border-b border-neutral-400 dark:border-neutral-600 p-1 ${className || ''}`}>
             <input
                 readOnly={disabled}
-                className="pl-2 w-full read-only:bg-transparent read-only:border-transparent read-only:focus:outline-none" 
+                className="pl-2 w-full read-only:bg-transparent read-only:border-transparent read-only:focus:outline-none"
                 value={entryData[dbKey] ?? 'N/A'}
                 onChange={(e) => onChangeHandler(e)}
                 onClick={(e) => onClickHandler(e)}

--- a/src/components/TableHeading.jsx
+++ b/src/components/TableHeading.jsx
@@ -1,12 +1,13 @@
 import classNames from 'classnames';
 import { SortAscIcon, SortDescIcon } from '../assets/icons';
+import '../styles/Table.css';
 import React from 'react';
 
 export const TableHeading = ({ label, active, sortDirection, onClick }) => {
 
     const getSortIcon = () => {
         if (active && sortDirection) {
-            return sortDirection  === 'asc' ? <SortAscIcon /> : <SortDescIcon />;
+            return sortDirection === 'asc' ? <SortAscIcon /> : <SortDescIcon />;
         }
     };
 
@@ -17,7 +18,7 @@ export const TableHeading = ({ label, active, sortDirection, onClick }) => {
 
     return (
         <th className={thClasses} onClick={onClick}>
-           <div className="flex items-center justify-start pl-2">
+            <div className="flex items-center justify-start pl-2">
                 <span className="flex-1 mr-1 whitespace-nowrap">{label}</span>
                 <span className="flex-4 text-xl ml-1">{getSortIcon()}</span>
             </div>

--- a/src/styles/Table.css
+++ b/src/styles/Table.css
@@ -1,18 +1,16 @@
-.table-wrapper {
+.table-container {
     display: flex;
     flex-direction: column;
+    width: 100%;
     height: 100%;
 }
 
-.entries-container {
-    flex: 1;
-    overflow-x: hidden;
-    max-width: 100%;
+.resizable-table {
+    width: 100%;
+    table-layout: auto; /* Ensure auto layout for proper resizing */
 }
 
-.sticky-scrollbar {
-    position: sticky;
-    bottom: 0;
-    overflow-x: auto;
-    z-index: 10;
+.resizable-table th, .resizable-table td {
+    resize: horizontal; /* Allow resizing */
+    overflow: auto;
 }


### PR DESCRIPTION
Not entirely sure why this was removed in the first place. New branch from current main (11/20) then cherry picked commit [071af5a](https://github.com/evanhagood/desktop-data-manager/commit/071af5a688a18f5d9bf23e4bb4fb082ba7d83a97) from branch [USX-AdjustableColumnWidthsFix](https://github.com/evanhagood/desktop-data-manager/tree/USX-AdjustableColumnWidthsFix)